### PR TITLE
Changed column names in the parser

### DIFF
--- a/release_notes/parser.py
+++ b/release_notes/parser.py
@@ -16,8 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class _Column(StrEnum):
-    PRODUCT = "Component/S"
-    RELEASE_NOTE = "Release Notes*"
+    PRODUCT = "Components"
+    RELEASE_NOTE = "Custom field (Release Notes*)"
     CHANGE_TYPE = "Change"
 
 


### PR DESCRIPTION
Adjusted the column names in parser so that csv files directly exported from JIRA can be used with the release notes generator.